### PR TITLE
Depend on testng 6.9.10: 6.9.12 no longer available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>6.9.12</version>
+                <version>6.9.10</version>
             </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>


### PR DESCRIPTION
Version 6.9.12 is no longer available on maven central.
Version 6.9.10 is the most recent version available on maven central which does not exhibit issues with `@dependsOnMethods` and `@dependsOnGroups` in our projects.