### PR TITLE
xml-apis:1.4.01 actually seems to be more recent than 2.0.2. Go figure…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
             <dependency>
                 <groupId>xml-apis</groupId>
                 <artifactId>xml-apis</artifactId>
-                <version>2.0.2</version>
+                <version>1.4.01</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
http://stackoverflow.com/questions/29354632/confusing-transistive-dependency-behavior-with-xml-apis
http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22xml-apis%22%20AND%20a%3A%22xml-apis%22 timestamps