### PR TITLE
Revert "configure docker-maven-plugin to always pull images"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,7 +407,6 @@
                         <verbose>true</verbose>
                         <showLogs>true</showLogs>
                         <logDate>DEFAULT</logDate>
-                        <autoPull>always</autoPull>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Reverts dhatim/root-pom-oss#25

This option shouldn't be applied globally, but on a per-image basis.