### PR TITLE
enforce minimal maven version the right way

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -502,6 +502,9 @@
                         </goals>
                         <configuration>
                             <rules>
+                                <requireMavenVersion>
+                                    <version>3.3.3</version>
+                                </requireMavenVersion>
                                 <requireReleaseDeps>
                                     <onlyWhenRelease>true</onlyWhenRelease>
                                 </requireReleaseDeps>
@@ -512,7 +515,7 @@
                                         <additionalPlugin>org.apache.maven.plugins:maven-idea-plugin</additionalPlugin>
                                     </additionalPlugins>
                                 </requirePluginVersions>
-                                <dependencyConvergence></dependencyConvergence>
+                                <dependencyConvergence/>
                             </rules>
                             <fail>true</fail>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,6 @@
         </developer>
     </developers>
 
-    <prerequisites>
-        <maven>3.1.0</maven>
-    </prerequisites>
-
     <scm>
         <connection>scm:git:git@github.com:dhatim/root-pom-oss.git</connection>
         <developerConnection>scm:git:ssh://github.com:dhatim/root-pom-oss.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -503,7 +503,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.3.3</version>
+                                    <version>3.2.5</version>
                                 </requireMavenVersion>
                                 <requireReleaseDeps>
                                     <onlyWhenRelease>true</onlyWhenRelease>


### PR DESCRIPTION

see e.g.
- https://maven.apache.org/pom.html#Prerequisites
- http://blog.soebes.de/blog/2015/04/04/maven-prerequisites/
- https://stackoverflow.com/questions/10511501/can-and-should-a-maven-pom-specify-if-it-requires-maven-3-or-newer