### PR TITLE
Raven is deprecated, use sentry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,6 @@
                 <version>1.72</version>
             </dependency>
             <dependency>
-                <groupId>com.getsentry.raven</groupId>
-                <artifactId>raven-logback</artifactId>
-                <version>8.0.3</version>
-            </dependency>
-            <dependency>
                 <groupId>com.github.jsqlparser</groupId>
                 <artifactId>jsqlparser</artifactId>
                 <version>1.1</version>
@@ -115,6 +110,11 @@
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt</artifactId>
                 <version>0.9.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry-logback</artifactId>
+                <version>1.7.3</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger</groupId>


### PR DESCRIPTION
This is a breaking change: see https://docs.sentry.io/clients/java/migration/.