### PR TITLE
Migrate to sentry-logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,13 +228,13 @@
             </dependency>
             <dependency>
                 <groupId>org.dhatim</groupId>
-                <artifactId>dropwizard-raven</artifactId>
-                <version>1.2.0-1</version>
+                <artifactId>dropwizard-sentry</artifactId>
+                <version>1.3.1-1</version>
             </dependency>
             <dependency>
                 <groupId>org.dhatim</groupId>
                 <artifactId>fastexcel</artifactId>
-                <version>0.9.0</version>
+                <version>0.9.1</version>
             </dependency>
             <dependency>
                 <groupId>org.dhatim</groupId>
@@ -314,7 +314,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.17.0</version>
+                <version>2.18.0</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>
@@ -349,7 +349,7 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>6.14.2</version>
+                <version>6.14.3</version>
             </dependency>
             <dependency>
                 <groupId>org.webjars</groupId>
@@ -369,12 +369,12 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.20</version>
+                <version>1.21</version>
             </dependency>
             <dependency>
                 <groupId>uk.com.robust-it</groupId>
                 <artifactId>cloning</artifactId>
-                <version>1.9.9</version>
+                <version>1.9.10</version>
             </dependency>
             <dependency>
                 <groupId>xml-apis</groupId>
@@ -542,7 +542,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.25.0</version>
+                    <version>0.25.2</version>
                     <configuration>
                         <verbose>true</verbose>
                         <showLogs>true</showLogs>


### PR DESCRIPTION
Step 2: reference `dropwizard-sentry` instead of `dropwizard-raven` (deprecated).
And upgrade other dependencies...